### PR TITLE
修正: Ganttロケールに関するモジュール指定子エラーの解決

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
   build: {
     rollupOptions: {
       external: [
-        'dhtmlx-gantt/codebase/locale/locale_jp.js'
       ]
     }
   }


### PR DESCRIPTION
vite.config.ts の外部依存関係から 'dhtmlx-gantt/codebase/locale/locale_jp.js' を削除します。これにより、Viteがこのロケールファイルをバンドルできるようになり、デプロイされたサイトでのパス解決エラーを防ぎます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **その他**
  - ビルドプロセスの調整により、一部の日本語ロケールファイルの取り扱いが変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->