### PR TITLE
修正: GanttChart タスクの追加で TypeError を処理する

### DIFF
--- a/src/components/GanttChart.test.tsx
+++ b/src/components/GanttChart.test.tsx
@@ -452,7 +452,6 @@ describe("handleAddTask and JSON Export", () => {
 		const mockToday = new Date(2024, 3, 10); // April 10, 2024
 		vi.setSystemTime(mockToday);
 		(gantt.uid as vi.Mock).mockReturnValue("test-uid-123");
-		(gantt.date.str_to_date as vi.Mock).mockImplementation((dateStr) => new Date(dateStr));
 		(gantt.calculateEndDate as vi.Mock).mockImplementation(({ start_date, duration }) => {
 			const endDate = new Date(start_date);
 			endDate.setDate(start_date.getDate() + duration);

--- a/src/components/GanttChart.tsx
+++ b/src/components/GanttChart.tsx
@@ -485,7 +485,8 @@ const GanttChart: React.FC = () => {
 
 		// Calculate end_date
 		const dateFormat = gantt.config.date_format || "%Y-%m-%d"; // Provide a fallback or ensure it's set
-		const startDateObj = gantt.date.str_to_date(newTask.start_date, dateFormat);
+		const dateParts = newTask.start_date.split('-');
+		const startDateObj = new Date(parseInt(dateParts[0]), parseInt(dateParts[1]) - 1, parseInt(dateParts[2]));
 
 		if (startDateObj && typeof newTask.duration === 'number') {
 			const endDateObj = gantt.calculateEndDate({


### PR DESCRIPTION
ガントチャートの「タスクを追加」ボタンをクリックすると、TypeError: `Object.str_to_date` で null のプロパティを読み取れません ('length' を読み取っています) が発生していました。このエラーは、`gantt.date.str_to_date` ライブラリ関数に起因していました。

このコミットでは、`src/components/GanttChart.tsx` の `handleAddTask` 関数を修正することでこの問題に対処します。新しいタスクの初期開始日文字列を解析するために `gantt.date.str_to_date` に依存するのではなく、日付文字列 (例: "YYYY-MM-DD") を手動で JavaScript の `Date` オブジェクトに解析します。このオブジェクトは、`gantt.calculateEndDate` による終了日の計算に使用されます。

状態に保存され、Gantt によって解析される `newTask.start_date` プロパティと `newTask.end_date` プロパティは、`formatDate` ユーティリティによってフォーマットされた文字列のままです。

TDD の原則（報告されたバグが失敗したテストとして扱われる）にヒントを得たこのアプローチは、重要な日付解析ステップにおける問題のあるライブラリ呼び出しを回避します。

`src/components/GanttChart.test.tsx` 内の対応する単体テスト「handleAddTask は、end_date を正しく計算して新しいタスクに追加します」は、この変更を反映するように更新されました。変更されたコード部分の `gantt.date.str_to_date` のモックは、その特定のパスでは実行されなくなったため、削除されました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - タスクの開始日の計算方法が改善され、日付の解析がより正確になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->