### PR TITLE
新機能: ウェブツールに三目並べゲームを追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import BmiPage from "./pages/BmiPage";
 import GanttPage from "./pages/GanttPage";
 import HomePage from "./pages/HomePage";
 import TemperaturePage from "./pages/TemperaturePage";
+import TicTacToePage from "./pages/TicTacToePage";
 
 function App() {
 	return (
@@ -34,6 +35,12 @@ function App() {
 						>
 							ガントチャート
 						</NavLink>
+						<NavLink
+							to="/tic-tac-toe"
+							className={({ isActive }) => (isActive ? styles.active : "")}
+						>
+							〇×ゲーム
+						</NavLink>
 					</div>
 				</nav>
 			</header>
@@ -43,6 +50,7 @@ function App() {
 					<Route path="/bmi-calculator" element={<BmiPage />} />
 					<Route path="/temperature-converter" element={<TemperaturePage />} />
 					<Route path="/gantt" element={<GanttPage />} />
+					<Route path="/tic-tac-toe" element={<TicTacToePage />} />
 				</Routes>
 			</main>
 			<footer className={styles.appFooter}>

--- a/src/components/TicTacToe.module.css
+++ b/src/components/TicTacToe.module.css
@@ -1,0 +1,57 @@
+.ticTacToe {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-family: sans-serif;
+}
+
+.status {
+  margin-bottom: 10px;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  width: 300px;
+  height: 300px;
+  border: 2px solid black;
+}
+
+.boardRow {
+  display: contents; /* Allows squares to be direct children of the grid */
+}
+
+.square {
+  width: 100px;
+  height: 100px;
+  background-color: #fff;
+  border: 1px solid #999;
+  font-size: 36px;
+  font-weight: bold;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.square:hover {
+  background-color: #f0f0f0;
+}
+
+.resetButton {
+  margin-top: 20px;
+  padding: 10px 20px;
+  font-size: 16px;
+  cursor: pointer;
+  background-color: #4caf50;
+  color: white;
+  border: none;
+  border-radius: 5px;
+}
+
+.resetButton:hover {
+  background-color: #45a049;
+}

--- a/src/components/TicTacToe.test.tsx
+++ b/src/components/TicTacToe.test.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TicTacToe from './TicTacToe';
+
+describe('TicTacToe Component', () => {
+  // Helper function to get all square buttons
+  const getSquares = () => screen.getAllByRole('button', { name: /^[XO]$|^$/i });
+  // Helper function to get the reset button (name can vary based on implementation)
+  const getResetButton = () => screen.getByRole('button', { name: /reset game/i });
+  // Helper function to get the status display
+  const getStatus = () => screen.getByText(/Next player:|Winner:|It's a draw!/i);
+
+  test('initial render: displays 9 cells, initial status, and reset button', () => {
+    render(<TicTacToe />);
+    const squares = getSquares();
+    expect(squares).toHaveLength(9);
+    squares.forEach(square => expect(square).toHaveTextContent(''));
+    expect(getStatus()).toHaveTextContent('Next player: X');
+    expect(getResetButton()).toBeInTheDocument();
+  });
+
+  test('making a move: updates cell and status', () => {
+    render(<TicTacToe />);
+    const squares = getSquares();
+    fireEvent.click(squares[0]);
+    expect(squares[0]).toHaveTextContent('X');
+    expect(getStatus()).toHaveTextContent('Next player: O');
+  });
+
+  test('alternating turns: X and O take turns correctly', () => {
+    render(<TicTacToe />);
+    const squares = getSquares();
+    fireEvent.click(squares[0]); // X
+    expect(squares[0]).toHaveTextContent('X');
+    expect(getStatus()).toHaveTextContent('Next player: O');
+    fireEvent.click(squares[1]); // O
+    expect(squares[1]).toHaveTextContent('O');
+    expect(getStatus()).toHaveTextContent('Next player: X');
+    fireEvent.click(squares[2]); // X
+    expect(squares[2]).toHaveTextContent('X');
+    expect(getStatus()).toHaveTextContent('Next player: O');
+  });
+
+  test('preventing moves on filled cells', () => {
+    render(<TicTacToe />);
+    const squares = getSquares();
+    fireEvent.click(squares[0]); // X's turn, clicks cell 0
+    expect(squares[0]).toHaveTextContent('X');
+    expect(getStatus()).toHaveTextContent('Next player: O');
+
+    fireEvent.click(squares[0]); // O's turn, clicks cell 0 again (should not change)
+    expect(squares[0]).toHaveTextContent('X'); // Still X
+    expect(getStatus()).toHaveTextContent('Next player: O'); // Still O's turn
+  });
+
+  test('win condition: X wins', () => {
+    render(<TicTacToe />);
+    const squares = getSquares();
+    // X O X
+    // O X O
+    // X - -
+    fireEvent.click(squares[0]); // X
+    fireEvent.click(squares[3]); // O
+    fireEvent.click(squares[1]); // X
+    fireEvent.click(squares[4]); // O
+    fireEvent.click(squares[2]); // X wins on top row
+
+    expect(getStatus()).toHaveTextContent('Winner: X');
+    // Check if squares are disabled (or click doesn't change)
+    fireEvent.click(squares[5]); // Try clicking another cell
+    expect(squares[5]).toHaveTextContent(''); // Should remain empty
+    expect(squares[5]).toBeDisabled();
+  });
+
+  test('win condition: O wins', () => {
+    render(<TicTacToe />);
+    const squares = getSquares();
+    // X X O
+    // X O -
+    // O - -
+    fireEvent.click(squares[0]); // X
+    fireEvent.click(squares[2]); // O
+    fireEvent.click(squares[1]); // X
+    fireEvent.click(squares[4]); // O
+    fireEvent.click(squares[3]); // X
+    fireEvent.click(squares[6]); // O wins on left column
+
+    expect(getStatus()).toHaveTextContent('Winner: O');
+    fireEvent.click(squares[5]);
+    expect(squares[5]).toHaveTextContent('');
+    expect(squares[5]).toBeDisabled();
+  });
+
+  test('draw condition', () => {
+    render(<TicTacToe />);
+    const squares = getSquares();
+    // X O X
+    // X O X
+    // O X O
+    fireEvent.click(squares[0]); // X
+    fireEvent.click(squares[1]); // O
+    fireEvent.click(squares[2]); // X
+    fireEvent.click(squares[4]); // O
+    fireEvent.click(squares[3]); // X
+    fireEvent.click(squares[5]); // O
+    fireEvent.click(squares[7]); // X
+    fireEvent.click(squares[6]); // O
+    fireEvent.click(squares[8]); // X - Draw
+
+    expect(getStatus()).toHaveTextContent("It's a draw!");
+    fireEvent.click(squares[0]); // Try clicking a filled cell
+    expect(squares[0]).toHaveTextContent('X'); // Should not change
+    expect(squares[0]).toBeDisabled(); // All should be disabled
+  });
+
+  test('resetting the game after a win', () => {
+    render(<TicTacToe />);
+    const squares = getSquares();
+    fireEvent.click(squares[0]); // X
+    fireEvent.click(squares[3]); // O
+    fireEvent.click(squares[1]); // X
+    fireEvent.click(squares[4]); // O
+    fireEvent.click(squares[2]); // X wins
+    expect(getStatus()).toHaveTextContent('Winner: X');
+
+    fireEvent.click(getResetButton());
+
+    expect(getStatus()).toHaveTextContent('Next player: X');
+    squares.forEach(square => {
+      expect(square).toHaveTextContent('');
+      expect(square).not.toBeDisabled();
+    });
+
+    // Verify game can be played again
+    fireEvent.click(squares[0]);
+    expect(squares[0]).toHaveTextContent('X');
+    expect(getStatus()).toHaveTextContent('Next player: O');
+  });
+
+  test('resetting the game after a draw', () => {
+    render(<TicTacToe />);
+    const squares = getSquares();
+    // Draw sequence
+    fireEvent.click(squares[0]); fireEvent.click(squares[1]); fireEvent.click(squares[2]);
+    fireEvent.click(squares[3]); fireEvent.click(squares[5]); fireEvent.click(squares[4]);
+    fireEvent.click(squares[6]); fireEvent.click(squares[8]); fireEvent.click(squares[7]);
+    // This sequence leads to a draw based on common implementations
+    // X O X
+    // O X O
+    // X X O -> Draw if calculateWinner checks board fullness after win lines
+    // Let's adjust the draw test sequence to be more robust or use the one from above
+    // Using the confirmed draw sequence:
+    // X O X
+    // X O X
+    // O X O
+    // Re-doing clicks for clarity for this test:
+    fireEvent.click(getSquares()[0]); // X
+    fireEvent.click(getSquares()[1]); // O
+    fireEvent.click(getSquares()[2]); // X
+    fireEvent.click(getSquares()[4]); // O
+    fireEvent.click(getSquares()[3]); // X
+    fireEvent.click(getSquares()[5]); // O
+    fireEvent.click(getSquares()[7]); // X
+    fireEvent.click(getSquares()[6]); // O
+    fireEvent.click(getSquares()[8]); // X - Draw
+
+    expect(getStatus()).toHaveTextContent("It's a draw!");
+
+    fireEvent.click(getResetButton());
+
+    expect(getStatus()).toHaveTextContent('Next player: X');
+    getSquares().forEach(square => {
+      expect(square).toHaveTextContent('');
+      expect(square).not.toBeDisabled();
+    });
+    // Verify game can be played again
+    fireEvent.click(getSquares()[0]);
+    expect(getSquares()[0]).toHaveTextContent('X');
+  });
+});

--- a/src/components/TicTacToe.tsx
+++ b/src/components/TicTacToe.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import styles from './TicTacToe.module.css';
+
+type Player = 'X' | 'O';
+type SquareValue = Player | null;
+
+const calculateWinner = (squares: SquareValue[]): SquareValue | 'Draw' => {
+  const lines = [
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+    [0, 3, 6],
+    [1, 4, 7],
+    [2, 5, 8],
+    [0, 4, 8],
+    [2, 4, 6],
+  ];
+  for (let i = 0; i < lines.length; i++) {
+    const [a, b, c] = lines[i];
+    if (squares[a] && squares[a] === squares[b] && squares[a] === squares[c]) {
+      return squares[a];
+    }
+  }
+  if (squares.every(square => square !== null)) {
+    return 'Draw';
+  }
+  return null;
+};
+
+const TicTacToe: React.FC = () => {
+  const [board, setBoard] = useState<SquareValue[]>(Array(9).fill(null));
+  const [currentPlayer, setCurrentPlayer] = useState<Player>('X');
+  const [winner, setWinner] = useState<SquareValue | 'Draw'>(null);
+
+  const handleClick = (index: number) => {
+    if (board[index] || winner) {
+      return;
+    }
+
+    const newBoard = [...board];
+    newBoard[index] = currentPlayer;
+    setBoard(newBoard);
+
+    const gameWinner = calculateWinner(newBoard);
+    if (gameWinner) {
+      setWinner(gameWinner);
+    } else {
+      setCurrentPlayer(currentPlayer === 'X' ? 'O' : 'X');
+    }
+  };
+
+  const resetGame = () => {
+    setBoard(Array(9).fill(null));
+    setCurrentPlayer('X');
+    setWinner(null);
+  };
+
+  const renderSquare = (index: number) => {
+    return (
+      <button
+        className={styles.square}
+        onClick={() => handleClick(index)}
+        disabled={!!winner || !!board[index]}
+      >
+        {board[index]}
+      </button>
+    );
+  };
+
+  let status;
+  if (winner) {
+    status = winner === 'Draw' ? "It's a draw!" : `Winner: ${winner}`;
+  } else {
+    status = `Next player: ${currentPlayer}`;
+  }
+
+  return (
+    <div className={styles.ticTacToe}>
+      <div className={styles.status}>{status}</div>
+      <div className={styles.board}>
+        {Array(3)
+          .fill(null)
+          .map((_, rowIndex) => (
+            <div key={rowIndex} className={styles.boardRow}>
+              {Array(3)
+                .fill(null)
+                .map((_, colIndex) => renderSquare(rowIndex * 3 + colIndex))}
+            </div>
+          ))}
+      </div>
+      <button className={styles.resetButton} onClick={resetGame}>
+        Reset Game
+      </button>
+    </div>
+  );
+};
+
+export default TicTacToe;

--- a/src/pages/TicTacToePage.tsx
+++ b/src/pages/TicTacToePage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import TicTacToe from '../components/TicTacToe';
+import styles from './ToolPage.module.css';
+
+const TicTacToePage: React.FC = () => {
+  return (
+    <div className={styles.toolPageContainer}>
+      <h1>Tic-Tac-Toe Game</h1>
+      <TicTacToe />
+      <div className={styles.backLinkContainer}>
+        <Link to="/" className={styles.backLink}>
+          ホームページに戻る
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default TicTacToePage;


### PR DESCRIPTION
このコミットでは、ウェブツールコレクションに新しい三目並べゲームを追加します。

主な変更点は以下のとおりです。
- **TicTacToe.tsx**: 三目並べゲームのロジック（プレイヤーのターン、勝ち/引き分けの検出、リセット機能など）を実装した新しいReactコンポーネントです。`TicTacToe.module.css` のCSSモジュールを使用してスタイル設定されています。
- **TicTacToePage.tsx**: 他のツールページと整合性を保ちながら、三目並べゲームを表示するための新しいページコンポーネントです。
- **App.tsx**: `/tic-tac-toe` パスのルーティングと、ヘッダーのナビゲーションリンク（「〇×ゲーム」）を追加しました。
- **TicTacToe.test.tsx**: `TicTacToe` コンポーネントの包括的なユニットテストを追加しました。着手、勝ち/引き分け条件、ゲームリセットなど、様々なゲームシナリオをカバーしています。

このゲームはシンプルでインタラクティブなユーザーエクスペリエンスを提供します。コンポーネントのロジックは、正しい動作を保証するために十分にテストされています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 「〇×ゲーム（Tic-Tac-Toe）」ページを追加しました。ナビゲーションバーからアクセスでき、3×3のマスで遊べるクラシックな〇×ゲームを提供します。
  - ゲームの勝敗や引き分け判定、リセット機能を搭載しています。

- **スタイル**
  - 〇×ゲーム専用のデザインとスタイルを追加しました。

- **テスト**
  - 〇×ゲームの基本動作やUI挙動を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->