### PR TITLE
Fix: Resolve React key warning and Gantt test error

### DIFF
--- a/src/components/GanttChart.test.tsx
+++ b/src/components/GanttChart.test.tsx
@@ -539,7 +539,7 @@ describe("handleAddTask and JSON Export", () => {
 		});
 
 		expect(mockCreateObjectURL).toHaveBeenCalled();
-		const blobArg = mockCreateObjectURL.mock.calls[0] as unknown as Blob;
+		const blobArg = mockCreateObjectURL.mock.calls[0][0] as Blob;
 
 		// Use FileReader to read Blob content as text, as blobArg.text() might not be available in JSDOM
 		const reader = new FileReader();

--- a/src/components/TicTacToe.tsx
+++ b/src/components/TicTacToe.tsx
@@ -55,9 +55,10 @@ const TicTacToe: React.FC = () => {
     setWinner(null);
   };
 
-  const renderSquare = (index: number) => {
+  const renderSquare = (index: number, key: string | number) => {
     return (
       <button
+        key={key}
         className={styles.square}
         onClick={() => handleClick(index)}
         disabled={!!winner || !!board[index]}
@@ -84,7 +85,10 @@ const TicTacToe: React.FC = () => {
             <div key={rowIndex} className={styles.boardRow}>
               {Array(3)
                 .fill(null)
-                .map((_, colIndex) => renderSquare(rowIndex * 3 + colIndex))}
+                .map((_, colIndex) => {
+                  const squareIndex = rowIndex * 3 + colIndex;
+                  return renderSquare(squareIndex, `square-${rowIndex}-${colIndex}`);
+                })}
             </div>
           ))}
       </div>


### PR DESCRIPTION
- Add unique key prop to rendered squares in TicTacToe component to prevent React warning.
- Correct GanttChart test to properly access the Blob object for FileReader, fixing a TypeError.

All tests pass after these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - GanttチャートのJSONエクスポートに関するテストの精度を向上しました。

- **リファクタ**
  - 三目並べ（TicTacToe）ボードの各マスに一意なReactキーを割り当てるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->