### PR TITLE
Normalize Godot export template setup and enable Pages deploy permissions

### DIFF
--- a/.github/workflows/dispatch-export.yml
+++ b/.github/workflows/dispatch-export.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event.inputs.export_platform == 'windows' || github.event.inputs.export_platform == 'all' }}
     container:
-      image: barichello/godot-ci:${{ env.GODOT_VERSION }}
+      image: barichello/godot-ci:${{ inputs.godot_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event.inputs.export_platform == 'linux' || github.event.inputs.export_platform == 'all' }}
     container:
-      image: barichello/godot-ci:${{ env.GODOT_VERSION }}
+      image: barichello/godot-ci:${{ inputs.godot_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event.inputs.export_platform == 'web' || github.event.inputs.export_platform == 'all' }}
     container:
-      image: barichello/godot-ci:${{ env.GODOT_VERSION }}
+      image: barichello/godot-ci:${{ inputs.godot_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event.inputs.export_platform == 'macos' || github.event.inputs.export_platform == 'all' }}
     container:
-      image: barichello/godot-ci:${{ env.GODOT_VERSION }}
+      image: barichello/godot-ci:${{ inputs.godot_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/dispatch-export.yml
+++ b/.github/workflows/dispatch-export.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event.inputs.export_platform == 'windows' || github.event.inputs.export_platform == 'all' }}
     container:
-      image: barichello/godot-ci:4.5
+      image: barichello/godot-ci:${{ env.GODOT_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event.inputs.export_platform == 'linux' || github.event.inputs.export_platform == 'all' }}
     container:
-      image: barichello/godot-ci:4.5
+      image: barichello/godot-ci:${{ env.GODOT_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event.inputs.export_platform == 'web' || github.event.inputs.export_platform == 'all' }}
     container:
-      image: barichello/godot-ci:4.5
+      image: barichello/godot-ci:${{ env.GODOT_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event.inputs.export_platform == 'macos' || github.event.inputs.export_platform == 'all' }}
     container:
-      image: barichello/godot-ci:4.5
+      image: barichello/godot-ci:${{ env.GODOT_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -173,7 +173,7 @@ jobs:
         run: |
           cd ${EXPORT_FOLDER}
           mkdir -v -p build/mac
-          godot -v --export-release "Mac OSX" ./build/mac/$EXPORT_NAME.zip
+          godot -v --export-release "macOS" ./build/mac/$EXPORT_NAME.zip
       - name: Upload Artifact
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/dispatch-export.yml
+++ b/.github/workflows/dispatch-export.yml
@@ -23,6 +23,9 @@ on:
         required: false
         default: "false"
 
+permissions:
+  contents: write
+
 env:
   GODOT_VERSION: ${{ github.event.inputs.godot_version }}
   EXPORT_PLATFORM: ${{ github.event.inputs.export_platform }}
@@ -79,8 +82,10 @@ jobs:
         uses: actions/checkout@v1
       - name: Setup
         run: |
-          mkdir -v -p ~/.local/share/godot/templates
-          mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
+          mkdir -v -p ~/.local/share/godot/export_templates/
+          mkdir -v -p ~/.config/
+          mv /root/.config/godot ~/.config/godot
+          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
       - name: Linux Build
         run: |
           cd ${EXPORT_FOLDER}
@@ -122,7 +127,7 @@ jobs:
         run: |
           cd ${EXPORT_FOLDER}
           mkdir -v -p build/web
-          godot -v --export-release "HTML5" ./build/web/index.html
+          godot -v --export-release "Web" ./build/web/index.html
       - name: Upload Artifact
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/push-export.yml
+++ b/.github/workflows/push-export.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
       # - "feature/**"
+permissions:
+  contents: write
 env:
   GODOT_VERSION: 4.5
   EXPORT_NAME: godot-game-template


### PR DESCRIPTION
### Motivation
- Ensure the dispatch/export jobs use the same Godot export templates and config layout used elsewhere so exports run correctly.  
- Give the GitHub Pages deploy action permission to push built web exports to `gh-pages`.  
- Fix the web export preset name so the correct Godot export is produced during web builds.

### Description
- Added `permissions: contents: write` to `.github/workflows/dispatch-export.yml` and `.github/workflows/push-export.yml` to allow the Pages deploy action to push to `gh-pages`.  
- Normalized Linux and other job setup to create `~/.local/share/godot/export_templates/` and `~/.config/` and move `/root/.config/godot` into `~/.config/godot` so the containerized runner finds Godot templates.  
- Updated the web export preset from `HTML5` to `Web` in `dispatch-export.yml` to match the project's Godot export preset.  
- Files modified: `.github/workflows/dispatch-export.yml` and `.github/workflows/push-export.yml`.

### Testing
- No automated unit or integration tests were run because these are workflow-only changes.  
- `CI` workflows were not executed as part of this change, so runtime validation of the workflows has not been performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a93fc9988331a44c24a7d2a10f4b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository write permission for export workflows.
  * Introduced new environment variables to control export outputs (including export folder/name and itch.io settings).
  * Centralized and relocated export templates and config paths for consistent setup across platforms.
  * Standardized platform export names to "Web" and "macOS" and made builds use the selected engine version dynamically.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->